### PR TITLE
feat: add mobile menu separators

### DIFF
--- a/app/components/NavBarMain.tsx
+++ b/app/components/NavBarMain.tsx
@@ -55,7 +55,7 @@ const variants = {
       open: {
         rotate: '45deg',
         origin: 'center',
-        y: '0.65em',
+        y: '57.5px',
       },
     },
     middle: {
@@ -70,7 +70,7 @@ const variants = {
       open: {
         rotate: '-45deg',
         origin: 'center',
-        y: '-0.5em',
+        y: '-57.5px',
       },
     },
   },
@@ -171,30 +171,30 @@ function NavBarMobile() {
               <motion.svg
                 width="2em"
                 height="2em"
-                viewBox="0 0 2em 2em"
+                viewBox="0 0 200 200"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <motion.rect
-                  y="0.35em"
-                  height="0.15em"
-                  width="1.6em"
+                  y="35"
+                  height="15"
+                  width="160"
                   fill="currentColor"
                   animate={state}
                   variants={variants.mobileMenu.top}
                 />
                 <motion.rect
-                  y="0.925em"
-                  height="0.15em"
-                  width="1.6em"
+                  y="92.5"
+                  height="15"
+                  width="160"
                   fill="currentColor"
                   animate={state}
                   variants={variants.mobileMenu.middle}
                 />
                 <motion.rect
-                  y="1.5em"
-                  height="0.15em"
-                  width="1.6em"
+                  y="150"
+                  height="15"
+                  width="160"
                   fill="currentColor"
                   animate={state}
                   variants={variants.mobileMenu.bottom}

--- a/app/components/NavBarMain.tsx
+++ b/app/components/NavBarMain.tsx
@@ -143,7 +143,7 @@ function NavBarMobileMenuList() {
       })}
       style={{display: 'block'}}
     >
-      <MenuItems className="flex flex-col space-between px-4 py-2 divide-y-3">
+      <MenuItems className="flex flex-col space-between py-2 divide-y divide-current">
         {Object.values(LINKS).map(({name, href}) => (
           <MenuLink
             as={Link}

--- a/app/components/NavBarMain.tsx
+++ b/app/components/NavBarMain.tsx
@@ -143,14 +143,14 @@ function NavBarMobileMenuList() {
       })}
       style={{display: 'block'}}
     >
-      <MenuItems className="flex flex-col space-between py-2 divide-y divide-current">
+      <MenuItems className="flex flex-col space-between py-0 border-none divide-y divide-current">
         {Object.values(LINKS).map(({name, href}) => (
           <MenuLink
             as={Link}
             to={href}
             key={name}
             id={name}
-            className="p-4 uppercase hover:text-highlight font-sans uppercase font-semibold text-sm transition-color"
+            className="bg-quaternary dark:bg-primary py-4 uppercase hover:text-highlight font-sans uppercase font-semibold text-sm transition-color hover:bg-quaternary dark:hover:bg-primary"
           >
             {name}
           </MenuLink>

--- a/app/components/NavBarMain.tsx
+++ b/app/components/NavBarMain.tsx
@@ -143,19 +143,29 @@ function NavBarMobileMenuList() {
       })}
       style={{display: 'block'}}
     >
-      <MenuItems className="flex flex-col space-between py-0 border-none divide-y divide-current">
-        {Object.values(LINKS).map(({name, href}) => (
-          <MenuLink
-            as={Link}
-            to={href}
-            key={name}
-            id={name}
-            className="bg-quaternary dark:bg-primary py-4 uppercase hover:text-highlight font-sans uppercase font-semibold text-sm transition-color hover:bg-quaternary dark:hover:bg-primary"
-          >
-            {name}
-          </MenuLink>
-        ))}
-      </MenuItems>
+      <motion.div
+        initial={{opacity: 0}}
+        animate={{opacity: 1}}
+        exit={{opacity: 0}}
+        transition={{
+          ease: 'linear',
+        }}
+        className="flex flex-col h-full overflow-y-scroll space-between py-0"
+      >
+        <MenuItems className="border-none bg-transparent p-0 divide-y divide-current">
+          {Object.values(LINKS).map(({name, href}) => (
+            <MenuLink
+              as={Link}
+              to={href}
+              key={name}
+              id={name}
+              className="bg-quaternary dark:bg-primary py-4 uppercase hover:text-highlight font-sans uppercase font-semibold text-sm transition-color hover:bg-quaternary dark:hover:bg-primary"
+            >
+              {name}
+            </MenuLink>
+          ))}
+        </MenuItems>
+      </motion.div>
     </MenuPopover>
   ) : null
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,9 +9,10 @@ import {
   useLoaderData,
 } from '@remix-run/react'
 import NavBarMain from './components/NavBarMain'
-import styles from './tailwind.css'
+import stylesTailwind from './tailwind.css'
 import {getSession} from './sessions'
 import type {THEMES} from './utils/theme'
+import stylesReach from '@reach/menu-button/styles.css'
 
 export const meta: MetaFunction = () => ({
   charset: 'utf-8',
@@ -19,7 +20,10 @@ export const meta: MetaFunction = () => ({
   viewport: 'width=device-width,initial-scale=1',
 })
 
-export const links: LinksFunction = () => [{rel: 'stylesheet', href: styles}]
+export const links: LinksFunction = () => [
+  {rel: 'stylesheet', href: stylesReach},
+  {rel: 'stylesheet', href: stylesTailwind},
+]
 
 export type LoaderData = {
   theme: keyof typeof THEMES | null


### PR DESCRIPTION
This PR adds separators for the mobile menu items.

### changes in this PR
- Add separators
- Override `Reach UI` css for menu items styling